### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  buildToolsVersion "21.0.0"
 
   defaultConfig {
     applicationId "chrisrenke.drawerarrowdrawable"
@@ -13,7 +13,7 @@ android {
   }
   buildTypes {
     release {
-      runProguard false
+      minifyEnabled false
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }


### PR DESCRIPTION
The Issue no 11 is resolved by changing -
runProguard false to minifyEnabled false
Note - Gradle must be 2.2 or above to use minifyEnabled

Also build tools changed to 21.0.0 to resolve following error - 

Error:Execution failed for task ':app:transformClassesWithDexForDebug'.
> com.android.build.api.transform.TransformException: java.lang.RuntimeException: java.lang.RuntimeException: com.android.ide.common.process.ProcessException: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Multi dex requires Build Tools 21.0.0 / Current: 20